### PR TITLE
Favor #fetch over #[]

### DIFF
--- a/lib/dbla/repository.rb
+++ b/lib/dbla/repository.rb
@@ -37,11 +37,12 @@ module Dbla
       end
     end
     def api_key
-      Dbla.config[:api_key]
+      Dbla.config.fetch(:api_key)
     end
 
     def url
-      @url ||= (Dbla.config[:url] + blacklight_config.document_model.name.downcase.pluralize).freeze
+      # REVIEW: What if the URL does not have a trailing /; Should it be `File.join?`
+      @url ||= (Dbla.config.fetch(:url) + blacklight_config.document_model.name.downcase.pluralize).freeze
     end
 
   end


### PR DESCRIPTION
In the case of configuration I'd prefer to have an early exception
saying that I have a missing configuration key.
