### PR TITLE
Expanding the allowable Rails

### DIFF
--- a/dbla.gemspec
+++ b/dbla.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "LICENSE", "Rakefile", "README.md"]
   s.test_files = Dir["spec/**/*"]
 
-  s.add_dependency "rails", "~> 4.1.10"
+  s.add_dependency "rails", "~> 4.1"
   s.add_dependency "blacklight", "~> 5.10"
 
   s.add_development_dependency "sqlite3"


### PR DESCRIPTION
Caveat: I encountered the following error after making these
adjustments; However I did get a search result of kitties!

``` console
NoMethodError (undefined method `export_formats' for nil:NilClass):
  blacklight (5.13.1) lib/blacklight/catalog.rb:174:in `additional_export_formats'
  blacklight (5.13.1) lib/blacklight/catalog.rb:63:in `block in show'
  actionpack (4.2.1) lib/action_controller/metal/mime_responds.rb:210:in `respond_to'
```
