### PR TITLE
Ignoring the Gemfile.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ test/dummy/db/*.sqlite3-journal
 test/dummy/log/*.log
 test/dummy/tmp/
 test/dummy/.sass-cache
+Gemfile.lock


### PR DESCRIPTION
> Do not check your Gemfile.lock into version control, since it
> enforces precision that does not exist in the gem command, which is
> used to install gems in practice.

http://yehudakatz.com/2010/12/16/clarifying-the-roles-of-the-gemspec-and-gemfile/
