### PR TITLE
Add Facets for US States and Countries

### DIFF
--- a/lib/generators/dbla/templates/catalog_controller.rb
+++ b/lib/generators/dbla/templates/catalog_controller.rb
@@ -69,6 +69,9 @@ class CatalogController < ApplicationController
     config.add_facet_field 'sourceResource.language.name', label: 'By Language'
     config.add_facet_field 'sourceResource.subject.name', label: 'By Subject'
     config.add_facet_field 'sourceResource.collection.id', label: 'Collection', display: false
+    config.add_facet_field 'sourceResource.spatial.state', label: 'By US State'
+    config.add_facet_field 'sourceResource.spatial.country', label: 'By Country'
+   
 
     # Have BL send all facet field names to Solr, which has been the default
     # previously. Simply remove these lines if you'd rather use Solr request


### PR DESCRIPTION
Adds spatial facets for US State and Country to the catalog_controller generator template.

Other spatial fields, like city and county, felt too messy and were left out. Neither provides state in which it is located, so a facet for Johnson County is just a hot mess. :boom:  

Address #13
